### PR TITLE
Modify test to support dispersal and retrieval

### DIFF
--- a/src/da.ts
+++ b/src/da.ts
@@ -1,6 +1,6 @@
 import { BlobStatus, BlobStatusRequest, DisperseBlobRequest, RetrieveBlobRequest } from "./gen/disperser/disperser_pb";
 import { DisperserClient } from "./gen/disperser/DisperserServiceClientPb";
-import { sleep, toStream, streamToString, toUint8Array, lessThan2MB, MB} from './utils';
+import { sleep, lessThan2MB, MB, chunkData, dechunkData} from './utils';
 
 type TEigenDaOptions = {
     uri: "mainnet" | "testnet" | `http://${string}` | `https://${string}`;
@@ -29,7 +29,7 @@ export class EigenDA {
     client: DisperserClient;
 
     static ACCOUNT = "eigenda-ts"
-    static URI_TESTNET = "disperser-holesky.eigenda.xyz:443"
+    static URI_TESTNET = "https://disperser-preprod-holesky-test.eigenda.xyz:443"
 
     constructor(options?: TEigenDaOptions) {
         switch (options?.uri) {
@@ -63,36 +63,26 @@ export class EigenDA {
             }
             (async () => {
                 try {
-                    console.log('Starting put operation with item:', item);
                     let contents = JSON.stringify(item);
-                    console.log('JSON stringified contents:', contents);
-
                     const encodedContents = new TextEncoder().encode(contents);
-                    console.log('Encoded data length:', encodedContents.length);
-
                     const blob = chunkData(encodedContents);
-                    console.log('Chunked blob length:', blob.length);
-
-                    const base64Encoded = Buffer.from(blob).toString('base64');
+                    const base64Encoded = Buffer.from(blob).toString('base64')
 
                     if (!lessThan2MB(blob)) {
                         throw new Error(`blob too large -- maximum compressed size is 2mb (got ${blob.length / MB}mb)`)
                     }
 
-                    console.log('Dispersing blob...');
                     const resp = await this.client.disperseBlob(
                         new DisperseBlobRequest()
                             .setData(base64Encoded)
                     )
                     const [requestId, result] = [resp.getRequestId(), resp.getResult()];
-                    console.log('Disperse blob response:', { requestId, result });
 
                     // spin while the blob's status isn't `BlobStatus::CONFIRMED, BlobStatus::FAILED, or BlobStatus::INSUFFICIENT_SIGNATURES`.
                     let latestRes = result;
                     let blobId: bigint | undefined; 
                     let batchHeaderHash: Uint8Array | string | undefined;
 
-                    console.log('Polling for blob status...');
                     do  {
                         await sleep(BlobPollPeriodMs);
                         let resp = await this.client.getBlobStatus(
@@ -111,14 +101,12 @@ export class EigenDA {
                         }
 
                         latestRes = resp.getStatus();
-                        console.log('Current blob status:', latestRes, 'Blob ID:', blobId, 'Batch Header Hash:', batchHeaderHash);
                     } while ((![BlobStatus.CONFIRMED, BlobStatus.FAILED, BlobStatus.INSUFFICIENT_SIGNATURES].includes(latestRes) && blobId === undefined));
 
                     if (!blobId || !batchHeaderHash) {
                         throw new Error('Failed to obtain Blob ID or Batch Header Hash');
                     }
 
-                    console.log('Put operation completed. Blob ID:', blobId, 'Batch Header Hash:', batchHeaderHash);
                     resolve({
                         id: blobId!,
                         batchHeaderHash: batchHeaderHash!
@@ -135,23 +123,15 @@ export class EigenDA {
 
     async get<T>(blobId: bigint, batchHeaderHash: Uint8Array | string): Promise<T> {
         try {
-            console.log('Starting get operation for blob ID:', blobId);
             const blob = await this.client.retrieveBlob(
                 new RetrieveBlobRequest()
                     .setBlobIndex(Number(blobId))
                     .setBatchHeaderHash(batchHeaderHash)
             );
             const base64Data = blob.getData() as string;
-            console.log('Retrieved base64 data length:', base64Data.length);
-
             const chunkedContents = Buffer.from(base64Data, 'base64');
-            console.log('Decoded chunked data length:', chunkedContents.length);
-
             const unchunkedContents = dechunkData(chunkedContents);
-            console.log('Unchunked data length:', unchunkedContents.length);
-
             const contentsAsText = new TextDecoder().decode(unchunkedContents);
-            console.log('Decoded text:', contentsAsText);
 
             return JSON.parse(contentsAsText) as T;
         } catch (e) {
@@ -164,34 +144,4 @@ export class EigenDA {
             throw new Error(`Failed to retrieve and process blob: ${e instanceof Error ? e.message : 'Unknown error'}`, {cause: e});
         }
     }
-}
-
-function chunkData(data: Uint8Array): Uint8Array {
-    const result = new Uint8Array(Math.ceil(data.length / 31) * 32);
-    let j = 0;
-    for (let i = 0; i < result.length; i++) {
-        if (i % 32 === 0) {
-            result[i] = 0; // Add empty byte at the start of each 32-byte chunk
-        } else {
-            result[i] = j < data.length ? data[j++] : 0;
-        }
-    }
-    return result;
-}
-
-function dechunkData(data: Uint8Array): Uint8Array {
-    const result = new Uint8Array(Math.floor(data.length / 32) * 31);
-    let j = 0;
-    for (let i = 0; i < data.length; i++) {
-        if (i % 32 !== 0) {
-            result[j++] = data[i];
-        }
-    }
-    // Find the last non-zero byte
-    let lastNonZeroIndex = result.length - 1;
-    while (lastNonZeroIndex >= 0 && result[lastNonZeroIndex] === 0) {
-        lastNonZeroIndex--;
-    }
-    // Return a new Uint8Array without trailing zeros
-    return result.slice(0, lastNonZeroIndex + 1);
 }

--- a/src/da.ts
+++ b/src/da.ts
@@ -1,6 +1,6 @@
 import { BlobStatus, BlobStatusRequest, DisperseBlobRequest, RetrieveBlobRequest } from "./gen/disperser/disperser_pb";
 import { DisperserClient } from "./gen/disperser/DisperserServiceClientPb";
-import { sleep, lessThan2MB, MB, chunkData, dechunkData} from './utils';
+import { sleep, lessThan2MB, MB, toBase64, base64ToUint8Array, chunkData, dechunkData} from './utils';
 
 type TEigenDaOptions = {
     uri: "mainnet" | "testnet" | `http://${string}` | `https://${string}`;
@@ -12,9 +12,25 @@ type TPutOptions = {
 
 const BlobPollPeriodMs = 1000;
 
-type EigenBlob = {
-    id: bigint;
-    batchHeaderHash: Uint8Array | string;
+export class EigenBlob<T> {
+    id: [bigint, Uint8Array | string]
+    constructor(id: [bigint, Uint8Array | string]) {
+        this.id = id;
+    }
+    toString() {
+        return `${this.id[0].toString()}-${toBase64(this.id[1])}`
+    }
+
+    static from<A>(serialized: string): EigenBlob<A> {
+        const parts = serialized.split('-');
+        if (parts.length != 2) {
+            throw new Error('invalid eigenblob.');
+        }
+        return new EigenBlob([
+            BigInt(parts[0]),
+            base64ToUint8Array(parts[1])
+        ])
+    }
 }
 
 /**
@@ -47,7 +63,7 @@ export class EigenDA {
         }
     }
 
-    put<T>(item: T, options?: TPutOptions): Promise<EigenBlob> {  
+    put<T>(item: T, options?: TPutOptions): Promise<EigenBlob<T>> {  
         return new Promise((resolve, reject) => {
             const didTimeout = {
                 did: false,
@@ -107,10 +123,9 @@ export class EigenDA {
                         throw new Error('Failed to obtain Blob ID or Batch Header Hash');
                     }
 
-                    resolve({
-                        id: blobId!,
-                        batchHeaderHash: batchHeaderHash!
-                    });
+                    resolve(new EigenBlob<T>(
+                        [blobId!, batchHeaderHash!],
+                    ));
                 } catch(e) {
                    console.error('Error in put operation:', e);
                    reject(e)
@@ -121,21 +136,19 @@ export class EigenDA {
         });
     }
 
-    async get<T>(blobId: bigint, batchHeaderHash: Uint8Array | string): Promise<T> {
+    async get<T>(request: EigenBlob<T>): Promise<T> {
         try {
             const blob = await this.client.retrieveBlob(
                 new RetrieveBlobRequest()
-                    .setBlobIndex(Number(blobId))
-                    .setBatchHeaderHash(batchHeaderHash)
+                    .setBlobIndex(Number(request.id[0]))
+                    .setBatchHeaderHash(request.id[1])
             );
             const base64Data = blob.getData() as string;
             const chunkedContents = Buffer.from(base64Data, 'base64');
             const unchunkedContents = dechunkData(chunkedContents);
             const contentsAsText = new TextDecoder().decode(unchunkedContents);
-
             return JSON.parse(contentsAsText) as T;
         } catch (e) {
-            console.error('Detailed error in get operation:', e);
             if (e instanceof Error) {
                 console.error('Error name:', e.name);
                 console.error('Error message:', e.message);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,6 @@ export const sleep = (timeMs: number) => {
     })
 }
 
-
 export const toStream = (arr: Uint8Array) => {
     return new ReadableStream({
         start(controller) {
@@ -28,6 +27,32 @@ export const streamToString = async (stream: ReadableStream): Promise<string> =>
     result += decoder.decode();
     return result;
 };
+
+export function base64ToUint8Array(base64: string) {
+    // Decode the Base64 string to a binary string
+    const binaryString = atob(base64);
+    
+    // Create a Uint8Array from the binary string
+    const length = binaryString.length;
+    const bytes = new Uint8Array(length);
+    
+    for (let i = 0; i < length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+    }
+    
+    return bytes;
+}
+
+export const toBase64 = (input: Uint8Array | string) => {
+    if (input instanceof Uint8Array) {
+        const binaryString = Array.from(input, byte => String.fromCharCode(byte)).join('');
+        return btoa(binaryString);
+    } else if (typeof input === 'string') {
+        return btoa(input);
+    } else {
+        throw new TypeError('Input must be a Uint8Array or a string');
+    }
+}
 
 export const streamToBase64 = async (stream: ReadableStream): Promise<string> => {
     const reader = stream.getReader();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,88 @@ export const streamToString = async (stream: ReadableStream): Promise<string> =>
     return result;
 };
 
+export const streamToBase64 = async (stream: ReadableStream): Promise<string> => {
+    const reader = stream.getReader();
+    let chunks: Uint8Array[] = [];
+
+    let chunk;
+    while (!(chunk = await reader.read()).done) {
+        chunks.push(chunk.value);
+    }
+
+    // Concatenate all chunks into a single Uint8Array
+    const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const fullUint8Array = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+        fullUint8Array.set(chunk, offset);
+        offset += chunk.length;
+    }
+
+    // Convert Uint8Array to a Base64-encoded string
+    const binaryString = Array.from(fullUint8Array, byte => String.fromCharCode(byte)).join('');
+    const base64Encoded = btoa(binaryString);
+
+    return base64Encoded;
+};
+
+export function chunkData(data: Uint8Array): Uint8Array {
+    const result = new Uint8Array(Math.ceil(data.length / 31) * 32);
+    let j = 0;
+    for (let i = 0; i < result.length; i++) {
+        if (i % 32 === 0) {
+            result[i] = 0; // Add empty byte at the start of each 32-byte chunk
+        } else {
+            result[i] = j < data.length ? data[j++] : 0;
+        }
+    }
+    return result;
+}
+
+export function dechunkData(data: Uint8Array): Uint8Array {
+    const result = new Uint8Array(Math.floor(data.length / 32) * 31);
+    let j = 0;
+    for (let i = 0; i < data.length; i++) {
+        if (i % 32 !== 0) {
+            result[j++] = data[i];
+        }
+    }
+    // Find the last non-zero byte
+    let lastNonZeroIndex = result.length - 1;
+    while (lastNonZeroIndex >= 0 && result[lastNonZeroIndex] === 0) {
+        lastNonZeroIndex--;
+    }
+    // Return a new Uint8Array without trailing zeros
+    return result.slice(0, lastNonZeroIndex + 1);
+}
+
+
+export const streamToHex = async (stream: ReadableStream): Promise<string> => {
+    const reader = stream.getReader();
+    let chunks: Uint8Array[] = [];
+
+    let chunk;
+    while (!(chunk = await reader.read()).done) {
+        chunks.push(chunk.value);
+    }
+
+    // Concatenate all chunks into a single Uint8Array
+    const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const fullUint8Array = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+        fullUint8Array.set(chunk, offset);
+        offset += chunk.length;
+    }
+
+    // Convert Uint8Array to a hex-encoded string
+    const hexEncoded = Array.from(fullUint8Array)
+        .map(byte => byte.toString(16).padStart(2, '0'))
+        .join('');
+
+    return hexEncoded;
+};
+
 
 export const toUint8Array = async (stream: ReadableStream): Promise<Uint8Array> => {
     const reader = stream.getReader();

--- a/tests/da.test.ts
+++ b/tests/da.test.ts
@@ -1,5 +1,4 @@
-import fetch from 'cross-fetch';
-import {EigenDA} from '../src/da';
+import {EigenDA, EigenBlob} from '../src/da';
 import {expect} from '@jest/globals';
 
 const {
@@ -14,9 +13,23 @@ global.DecompressionStream = DecompressionStream;
 
 const SECONDS = 1000;
 
-it("should be able to post a blob", async () => {
+it("should be able to post a JSON blob", async () => {
     const client = new EigenDA();
     const resp = await client.put({hello: 'world'});
-    const blob = await client.get<any>(resp.id, resp.batchHeaderHash);
+    const blob = await client.get(resp);
     expect(blob.hello).toEqual('world');
+}, 600 * SECONDS);
+
+it("should be able to post a binary blob", async () => {
+  const client = new EigenDA();
+  const resp = await client.put({pngBase64: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAgUBdssEZAAAAABJRU5ErkJggg=='});
+  const blob = await client.get(resp);
+  expect(blob.pngBase64).not.toBeNull();
+}, 600 * SECONDS);
+
+it("should be able to save an EigenBlob to string", async () => {
+  const blob = new EigenBlob([5n, new Uint8Array(new TextEncoder().encode("123"))]);
+  const val = blob.toString();
+  const blob2 = EigenBlob.from(val);
+  expect(blob.id).toEqual(blob2.id);
 }, 600 * SECONDS);

--- a/tests/da.test.ts
+++ b/tests/da.test.ts
@@ -15,17 +15,8 @@ global.DecompressionStream = DecompressionStream;
 const SECONDS = 1000;
 
 it("should be able to post a blob", async () => {
-    const client = new EigenDA({
-      uri: "https://disperser-preprod-holesky-test.eigenda.xyz:443",
-    }); // defaults to testnet
-
+    const client = new EigenDA();
     const resp = await client.put({hello: 'world'});
-
-    console.log('Response from put:', resp);
-    console.log('Response ID:', resp.id);
-
-
     const blob = await client.get<any>(resp.id, resp.batchHeaderHash);
-
     expect(blob.hello).toEqual('world');
 }, 600 * SECONDS);

--- a/tests/da.test.ts
+++ b/tests/da.test.ts
@@ -15,10 +15,17 @@ global.DecompressionStream = DecompressionStream;
 const SECONDS = 1000;
 
 it("should be able to post a blob", async () => {
-    const client = new EigenDA({uri: "http://localhost:7001"}); // defaults to testnet
+    const client = new EigenDA({
+      uri: "https://disperser-preprod-holesky-test.eigenda.xyz:443",
+    }); // defaults to testnet
 
     const resp = await client.put({hello: 'world'});
-    const blob = await client.get<any>(resp.id);
+
+    console.log('Response from put:', resp);
+    console.log('Response ID:', resp.id);
+
+
+    const blob = await client.get<any>(resp.id, resp.batchHeaderHash);
 
     expect(blob.hello).toEqual('world');
-}, 15 * SECONDS);
+}, 600 * SECONDS);


### PR DESCRIPTION
Test passes when querying endpoint behind envoy gateway.

Had to remove gzip encoding because I kept getting error like:
```
  console.error
    Detailed error in get operation: TypeError: 
        at handleKnownInternalErrors (node:internal/webstreams/adapters:115:21)
        at Gunzip.<anonymous> (node:internal/webstreams/adapters:475:13)
        at Gunzip.<anonymous> (node:internal/util:538:20)
        at Gunzip.onerror (node:internal/streams/end-of-stream:136:14)
        at Gunzip.emit (node:events:532:35)
        at emitErrorNT (node:internal/streams/destroy:170:8)
        at emitErrorCloseNT (node:internal/streams/destroy:129:3)
        at processTicksAndRejections (node:internal/process/task_queues:82:21) {
      code: 'Z_BUF_ERROR',
      [cause]: Error: unexpected end of file
          at genericNodeError (node:internal/errors:983:15)
          at wrappedFn (node:internal/errors:537:14)
          at Zlib.zlibOnError [as onerror] (node:zlib:191:17) {
        errno: -5,
        code: 'Z_BUF_ERROR'
      }
```